### PR TITLE
feat: open address in google earth

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -23,6 +23,7 @@
   "optAutoCopy": {
     "message": "Adresse nach Erkennung automatisch in die Zwischenablage kopieren"
   },
+  "optShowEarth": { "message": "Google Earth-Button im Overlay anzeigen" },
   "optSave": { "message": "Speichern" },
   "optSaved": { "message": "Gespeichert ✓" },
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -10,6 +10,7 @@
   "uiCopied": { "message": "Kopiert ✓" },
   "uiCopyFail": { "message": "Fehlgeschlagen" },
   "uiOpenMap": { "message": "Karte öffnen" },
+  "uiOpenEarth": { "message": "Google Earth öffnen" },
   "uiClose": { "message": "Schließen" },
   "uiNoAddress": { "message": "Keine Adresse gefunden" },
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -10,6 +10,7 @@
   "uiCopied": { "message": "Copied ✓" },
   "uiCopyFail": { "message": "Failed" },
   "uiOpenMap": { "message": "Open map" },
+  "uiOpenEarth": { "message": "Open Google Earth" },
   "uiClose": { "message": "Close" },
   "uiNoAddress": { "message": "No address found" },
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,6 +23,7 @@
   "optAutoCopy": {
     "message": "Automatically copy address to clipboard after detection"
   },
+  "optShowEarth": { "message": "Show Google Earth button in overlay" },
   "optSave": { "message": "Save" },
   "optSaved": { "message": "Saved ✓" },
 

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -19,6 +19,7 @@
   "optPosition": { "message": "Posición:" },
   "optTheme": { "message": "Tema:" },
   "optAutoCopy": { "message": "Copiar automáticamente la dirección al portapapeles al detectarla" },
+  "optShowEarth": { "message": "Mostrar botón de Google Earth en el overlay" },
   "optSave": { "message": "Guardar" },
   "optSaved": { "message": "Guardado ✓" },
 

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -8,6 +8,7 @@
   "uiCopied": { "message": "Copiado ✓" },
   "uiCopyFail": { "message": "Error" },
   "uiOpenMap": { "message": "Abrir mapa" },
+  "uiOpenEarth": { "message": "Abrir Google Earth" },
   "uiClose": { "message": "Cerrar" },
   "uiNoAddress": { "message": "No se encontró dirección" },
 

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -10,6 +10,7 @@
   "uiCopied": { "message": "Copiato ✓" },
   "uiCopyFail": { "message": "Errore" },
   "uiOpenMap": { "message": "Apri mappa" },
+  "uiOpenEarth": { "message": "Apri Google Earth" },
   "uiClose": { "message": "Chiudi" },
   "uiNoAddress": { "message": "Nessun indirizzo trovato" },
 

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -23,6 +23,7 @@
   "optAutoCopy": {
     "message": "Copia automaticamente l'indirizzo rilevato negli appunti"
   },
+  "optShowEarth": { "message": "Mostra il pulsante Google Earth nell'overlay" },
   "optSave": { "message": "Salva" },
   "optSaved": { "message": "Salvato ✓" },
 

--- a/options.html
+++ b/options.html
@@ -83,6 +83,10 @@
         <input type="checkbox" name="autoCopy">
         <span data-i18n="optAutoCopy">Adresse nach Erkennung automatisch in die Zwischenablage kopieren</span>
       </label>
+      <label class="row">
+        <input type="checkbox" name="showEarth">
+        <span data-i18n="optShowEarth">Google Earth-Button im Overlay anzeigen</span>
+      </label>
     </fieldset>
 
     <fieldset>

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -161,9 +161,8 @@ async function main(): Promise<void> {
   await copyStatics(outFirefox);
   await patchManifestFor('firefox', outFirefox);
 
-  // ZIPs (commented out by default)
-  // zipDir(outChrome, path.join(outDir, 'immo24-chromium.zip'));
-  // zipDir(outFirefox, path.join(outDir, 'immo24-firefox.zip'));
+  zipDir(outChrome, path.join(outDir, 'immo24-chromium.zip'));
+  zipDir(outFirefox, path.join(outDir, 'immo24-firefox.zip'));
 
   console.log('\n✅ Build finished:');
   console.log('   • dist/chromium/');

--- a/src/content.ts
+++ b/src/content.ts
@@ -145,6 +145,11 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
     return `https://www.google.com/maps/search/?api=1&query=${q}`;
   }
 
+  function buildEarthHref(parts: string[]) {
+    const q = encodeURIComponent(parts.filter(Boolean).join(' '));
+    return `https://earth.google.com/web/search/${q}`;
+  }
+
   function createOverlay(address: Address) {
     const { theme, position, mapProvider } = settings;
     const style = overlayBaseStyle(theme, position);
@@ -196,6 +201,13 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
     mapBtn.rel = 'noopener';
     mapBtn.textContent = t('uiOpenMap');
 
+    const earthBtn = document.createElement('a');
+    earthBtn.setAttribute('style', ghost + ' text-decoration:none; display:inline-flex; align-items:center; justify-content:center;')
+    earthBtn.href = buildEarthHref([street, houseNumber, postalCode, city]);
+    earthBtn.target = '_blank';
+    earthBtn.rel = 'noopener';
+    earthBtn.textContent = t('uiOpenEarth');
+
     const closeBtn = document.createElement('button');
     closeBtn.setAttribute('style', ghost);
     closeBtn.textContent = t('uiClose');
@@ -204,7 +216,7 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
       hideOverlay();
     });
 
-    actions.append(copyBtn, mapBtn, closeBtn);
+    actions.append(copyBtn, mapBtn, earthBtn, closeBtn);
     div.append(title, line, actions);
     document.documentElement.appendChild(div);
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -13,6 +13,7 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
   const DEFAULTS: Settings = {
     mapProvider: 'google',
     autoCopy: false,
+    showEarth: true,
     position: 'bottom-right',
     theme: 'dark',
     localeOverride: 'auto'
@@ -137,10 +138,13 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
       background: transparent; color: ${text}; font-weight: 600;
     `;
   }
-function closeButtonStyle(theme: Settings['theme']) {
+  function earthCornerStyle(theme: Settings['theme']) {
+    const border = (theme === 'light') ? 'rgba(17,24,39,.2)' : 'rgba(255,255,255,.2)';
     return `
-      position: absolute; top: 8px; right: 8px; width: 24px; height: 24px; border: none; background: transparent;
-      color: ${theme === 'light' ? '#111827' : '#fff'}; font-size: 18px; line-height: 1; cursor: pointer;
+      position: absolute; top: 6px; right: 8px; width: 24px; height: 24px;
+      border: 1px solid ${border}; border-radius: 6px; background: transparent;
+      font-size: 14px; line-height: 1; cursor: pointer; text-decoration: none;
+      display: inline-flex; align-items: center; justify-content: center;
     `;
   }
 
@@ -157,11 +161,10 @@ function closeButtonStyle(theme: Settings['theme']) {
   }
 
   function createOverlay(address: Address) {
-    const { theme, position, mapProvider } = settings;
+    const { theme, position, mapProvider, showEarth } = settings;
     const style = overlayBaseStyle(theme, position);
     const btn = buttonStyle(theme);
     const ghost = ghostStyle(theme);
-    const close = closeButtonStyle(theme);
 
     const div = document.createElement('div');
     div.id = 'is24-address-decoder-overlay';
@@ -208,23 +211,27 @@ function closeButtonStyle(theme: Settings['theme']) {
     mapBtn.rel = 'noopener';
     mapBtn.textContent = t('uiOpenMap');
 
-    const earthBtn = document.createElement('a');
-    earthBtn.setAttribute('style', ghost + ' text-decoration:none; display:inline-flex; align-items:center; justify-content:center;')
-    earthBtn.href = buildEarthHref([street, houseNumber, postalCode, city]);
-    earthBtn.target = '_blank';
-    earthBtn.rel = 'noopener';
-    earthBtn.textContent = t('uiOpenEarth');
-
     const closeBtn = document.createElement('button');
-    closeBtn.setAttribute('style', close);
-    closeBtn.textContent = 'X';
+    closeBtn.setAttribute('style', ghost);
+    closeBtn.textContent = t('uiClose');
     closeBtn.addEventListener('click', () => {
       overlayState = 'dismissed';
       hideOverlay();
     });
 
-    actions.append(copyBtn, mapBtn, earthBtn);
-    div.append(closeBtn, title, line, actions);
+    actions.append(copyBtn, mapBtn, closeBtn);
+    div.append(title, line, actions);
+
+    if (showEarth) {
+      const earthCornerBtn = document.createElement('a');
+      earthCornerBtn.setAttribute('style', earthCornerStyle(theme));
+      earthCornerBtn.href = buildEarthHref([street, houseNumber, postalCode, city]);
+      earthCornerBtn.target = '_blank';
+      earthCornerBtn.rel = 'noopener';
+      earthCornerBtn.title = t('uiOpenEarth');
+      earthCornerBtn.textContent = '🌍';
+      div.appendChild(earthCornerBtn);
+    }
     document.documentElement.appendChild(div);
 
     overlayEl = div;

--- a/src/content.ts
+++ b/src/content.ts
@@ -137,6 +137,12 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
       background: transparent; color: ${text}; font-weight: 600;
     `;
   }
+function closeButtonStyle(theme: Settings['theme']) {
+    return `
+      position: absolute; top: 8px; right: 8px; width: 24px; height: 24px; border: none; background: transparent;
+      color: ${theme === 'light' ? '#111827' : '#fff'}; font-size: 18px; line-height: 1; cursor: pointer;
+    `;
+  }
 
   function buildMapHref(provider: Settings['mapProvider'], parts: string[]) {
     const q = encodeURIComponent(parts.filter(Boolean).join(' '));
@@ -155,6 +161,7 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
     const style = overlayBaseStyle(theme, position);
     const btn = buttonStyle(theme);
     const ghost = ghostStyle(theme);
+    const close = closeButtonStyle(theme);
 
     const div = document.createElement('div');
     div.id = 'is24-address-decoder-overlay';
@@ -209,15 +216,15 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
     earthBtn.textContent = t('uiOpenEarth');
 
     const closeBtn = document.createElement('button');
-    closeBtn.setAttribute('style', ghost);
-    closeBtn.textContent = t('uiClose');
+    closeBtn.setAttribute('style', close);
+    closeBtn.textContent = 'X';
     closeBtn.addEventListener('click', () => {
       overlayState = 'dismissed';
       hideOverlay();
     });
 
-    actions.append(copyBtn, mapBtn, earthBtn, closeBtn);
-    div.append(title, line, actions);
+    actions.append(copyBtn, mapBtn, earthBtn);
+    div.append(closeBtn, title, line, actions);
     document.documentElement.appendChild(div);
 
     overlayEl = div;

--- a/src/options.ts
+++ b/src/options.ts
@@ -8,6 +8,7 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
 const DEFAULTS: Settings = {
   mapProvider: 'google',
   autoCopy: false,
+  showEarth: true,
   position: 'bottom-right',
   theme: 'dark',
   localeOverride: 'auto'
@@ -85,6 +86,7 @@ function applyTranslations() {
 const form = document.getElementById('form') as (HTMLFormElement & {
   mapProvider: HTMLSelectElement;
   autoCopy: HTMLInputElement;
+  showEarth: HTMLInputElement;
   position: HTMLSelectElement;
   theme: HTMLSelectElement;
   localeOverride?: HTMLSelectElement;
@@ -101,6 +103,7 @@ function load() {
     API.storage.sync.get(DEFAULTS, (items: Settings) => {
       form.mapProvider.value = items.mapProvider;
       form.autoCopy.checked = !!items.autoCopy;
+      form.showEarth.checked = !!items.showEarth;
       form.position.value = items.position;
       form.theme.value = items.theme;
       if ((form as any).localeOverride) {
@@ -115,6 +118,7 @@ function load() {
   
   form.mapProvider.value = DEFAULTS.mapProvider;
   form.autoCopy.checked = DEFAULTS.autoCopy;
+  form.showEarth.checked = DEFAULTS.showEarth;
   form.position.value = DEFAULTS.position;
   form.theme.value = DEFAULTS.theme;
   if ((form as any).localeOverride) {
@@ -143,6 +147,7 @@ form?.addEventListener('submit', (e) => {
   const data: Settings = {
     mapProvider: form.mapProvider.value as MapProvider,
     autoCopy: form.autoCopy.checked,
+    showEarth: form.showEarth.checked,
     position: form.position.value as Position,
     theme: form.theme.value as Theme,
     localeOverride: newLocale

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type LocaleOverride = 'auto' | 'de' | 'en' | 'es' | 'it';
 export interface Settings {
   mapProvider: MapProvider;
   autoCopy: boolean;
+  showEarth: boolean;
   position: Position;
   theme: Theme;
   localeOverride: LocaleOverride;

--- a/tests/e2e/translations.spec.ts
+++ b/tests/e2e/translations.spec.ts
@@ -15,6 +15,7 @@ test.describe('Overlay Translations', () => {
       'uiTitle': 'Adresse (IS24)',
       'uiCopy': 'Kopieren',
       'uiOpenMap': 'Karte öffnen',
+      'uiOpenEarth': 'Google Earth öffnen',
       'uiClose': 'Schließen',
       'uiNoAddress': 'Keine Adresse gefunden'
     };
@@ -23,6 +24,7 @@ test.describe('Overlay Translations', () => {
     expect(mockMessages.uiTitle).toBe('Adresse (IS24)');
     expect(mockMessages.uiCopy).toBe('Kopieren');
     expect(mockMessages.uiOpenMap).toBe('Karte öffnen');
+    expect(mockMessages.uiOpenEarth).toBe('Google Earth öffnen');
     expect(mockMessages.uiClose).toBe('Schließen');
   });
 
@@ -31,6 +33,7 @@ test.describe('Overlay Translations', () => {
       'uiTitle': 'Address (IS24)',
       'uiCopy': 'Copy',
       'uiOpenMap': 'Open map',
+      'uiOpenEarth': 'Open Google Earth',
       'uiClose': 'Close',
       'uiNoAddress': 'No address found'
     };
@@ -38,6 +41,7 @@ test.describe('Overlay Translations', () => {
     expect(mockMessages.uiTitle).toBe('Address (IS24)');
     expect(mockMessages.uiCopy).toBe('Copy');
     expect(mockMessages.uiOpenMap).toBe('Open map');
+    expect(mockMessages.uiOpenEarth).toBe('Open Google Earth');
     expect(mockMessages.uiClose).toBe('Close');
   });
 
@@ -46,6 +50,7 @@ test.describe('Overlay Translations', () => {
       'uiTitle': 'Dirección (IS24)',
       'uiCopy': 'Copiar',
       'uiOpenMap': 'Abrir mapa',
+      'uiOpenEarth': 'Abrir Google Earth',
       'uiClose': 'Cerrar',
       'uiNoAddress': 'No se encontró dirección'
     };
@@ -53,6 +58,7 @@ test.describe('Overlay Translations', () => {
     expect(mockMessages.uiTitle).toBe('Dirección (IS24)');
     expect(mockMessages.uiCopy).toBe('Copiar');
     expect(mockMessages.uiOpenMap).toBe('Abrir mapa');
+    expect(mockMessages.uiOpenEarth).toBe('Abrir Google Earth');
     expect(mockMessages.uiClose).toBe('Cerrar');
   });
 
@@ -61,6 +67,7 @@ test.describe('Overlay Translations', () => {
       'uiTitle': 'Indirizzo (IS24)',
       'uiCopy': 'Copia',
       'uiOpenMap': 'Apri mappa',
+      'uiOpenEarth': 'Apri Google Earth',
       'uiClose': 'Chiudi',
       'uiNoAddress': 'Nessun indirizzo trovato'
     };
@@ -68,6 +75,7 @@ test.describe('Overlay Translations', () => {
     expect(mockMessages.uiTitle).toBe('Indirizzo (IS24)');
     expect(mockMessages.uiCopy).toBe('Copia');
     expect(mockMessages.uiOpenMap).toBe('Apri mappa');
+    expect(mockMessages.uiOpenEarth).toBe('Apri Google Earth');
     expect(mockMessages.uiClose).toBe('Chiudi');
   });
 });
@@ -81,6 +89,7 @@ test.describe('Locale Bundle Loading', () => {
     expect(locale.uiCopy.message).toBe('Kopieren');
     expect(locale.uiCopied.message).toBe('Kopiert ✓');
     expect(locale.uiOpenMap.message).toBe('Karte öffnen');
+    expect(locale.uiOpenEarth.message).toBe('Google Earth öffnen');
     expect(locale.uiClose.message).toBe('Schließen');
   });
 
@@ -92,6 +101,7 @@ test.describe('Locale Bundle Loading', () => {
     expect(locale.uiCopy.message).toBe('Copy');
     expect(locale.uiCopied.message).toBe('Copied ✓');
     expect(locale.uiOpenMap.message).toBe('Open map');
+    expect(locale.uiOpenEarth.message).toBe('Open Google Earth');
     expect(locale.uiClose.message).toBe('Close');
   });
 
@@ -103,6 +113,7 @@ test.describe('Locale Bundle Loading', () => {
     expect(locale.uiCopy.message).toBe('Copiar');
     expect(locale.uiCopied.message).toBe('Copiado ✓');
     expect(locale.uiOpenMap.message).toBe('Abrir mapa');
+    expect(locale.uiOpenEarth.message).toBe('Abrir Google Earth');
     expect(locale.uiClose.message).toBe('Cerrar');
   });
 
@@ -114,6 +125,7 @@ test.describe('Locale Bundle Loading', () => {
     expect(locale.uiCopy.message).toBe('Copia');
     expect(locale.uiCopied.message).toBe('Copiato ✓');
     expect(locale.uiOpenMap.message).toBe('Apri mappa');
+    expect(locale.uiOpenEarth.message).toBe('Apri Google Earth');
     expect(locale.uiClose.message).toBe('Chiudi');
   });
 });
@@ -121,7 +133,7 @@ test.describe('Locale Bundle Loading', () => {
 test.describe('Locale Completeness', () => {
   const requiredKeys = [
     'extName', 'extDesc', 'cmdToggle',
-    'uiTitle', 'uiCopy', 'uiCopied', 'uiCopyFail', 'uiOpenMap', 'uiClose', 'uiNoAddress',
+    'uiTitle', 'uiCopy', 'uiCopied', 'uiCopyFail', 'uiOpenMap', 'uiOpenEarth', 'uiClose', 'uiNoAddress',
     'optTitle', 'optLegendMap', 'optLegendOverlay', 'optMapProvider', 'optPosition', 'optTheme', 'optAutoCopy',
     'optSave', 'optSaved',
     'optGoogle', 'optOsm', 'optApple',
@@ -227,6 +239,7 @@ test.describe('Locale Switching E2E', () => {
       expect(data.uiTitle).toBeDefined();
       expect(data.uiCopy).toBeDefined();
       expect(data.uiOpenMap).toBeDefined();
+      expect(data.uiOpenEarth).toBeDefined();
       expect(data.uiClose).toBeDefined();
     }
   });
@@ -253,6 +266,12 @@ test.describe('Locale Switching E2E', () => {
     expect(locale_en.uiOpenMap.message).toBe('Open map');
     expect(locale_es.uiOpenMap.message).toBe('Abrir mapa');
     expect(locale_it.uiOpenMap.message).toBe('Apri mappa');
+
+    // uiOpenEarth should be different in each language
+    expect(locale_de.uiOpenEarth.message).toBe('Google Earth öffnen');
+    expect(locale_de.uiOpenEarth.message).toBe('Open Google Earth');
+    expect(locale_de.uiOpenEarth.message).toBe('Abrir Earth öffnen');
+    expect(locale_de.uiOpenEarth.message).toBe('Apri Earth öffnen');
   });
 
   test('should preserve locale structure across all languages', async ({ page }) => {

--- a/tests/unit/overlay-translations.test.ts
+++ b/tests/unit/overlay-translations.test.ts
@@ -9,6 +9,7 @@ describe('Overlay Translation Logic', () => {
         uiCopy: 'Kopieren',
         uiCopied: 'Kopiert ✓',
         uiOpenMap: 'Karte öffnen',
+        uiOpenEarth: 'Google Earth öffnen',
         uiClose: 'Schließen',
         uiNoAddress: 'Keine Adresse gefunden'
       },
@@ -17,6 +18,7 @@ describe('Overlay Translation Logic', () => {
         uiCopy: 'Copy',
         uiCopied: 'Copied ✓',
         uiOpenMap: 'Open map',
+        uiOpenEarth: 'Open Google Earth',
         uiClose: 'Close',
         uiNoAddress: 'No address found'
       },
@@ -25,6 +27,7 @@ describe('Overlay Translation Logic', () => {
         uiCopy: 'Copiar',
         uiCopied: 'Copiado ✓',
         uiOpenMap: 'Abrir mapa',
+        uiOpenEarth: 'Abrir Google Earth',
         uiClose: 'Cerrar',
         uiNoAddress: 'No se encontró dirección'
       },
@@ -33,6 +36,7 @@ describe('Overlay Translation Logic', () => {
         uiCopy: 'Copia',
         uiCopied: 'Copiato ✓',
         uiOpenMap: 'Apri mappa',
+        uiOpenEarth: 'Apri Google Earth',
         uiClose: 'Chiudi',
         uiNoAddress: 'Nessun indirizzo trovato'
       }
@@ -173,6 +177,7 @@ describe('Overlay Translation Logic', () => {
           <h3>${t('uiTitle')}</h3>
           <button>${t('uiCopy')}</button>
           <button>${t('uiOpenMap')}</button>
+          <button>${t('uiOpenEarth')}</button>
           <button>${t('uiClose')}</button>
         </div>
       `;
@@ -180,6 +185,7 @@ describe('Overlay Translation Logic', () => {
       expect(overlayHTML).toContain('Adresse (IS24)');
       expect(overlayHTML).toContain('Kopieren');
       expect(overlayHTML).toContain('Karte öffnen');
+      expect(overlayHTML).toContain('Google Earth öffnen');
       expect(overlayHTML).toContain('Schließen');
     });
 
@@ -192,6 +198,7 @@ describe('Overlay Translation Logic', () => {
           <h3>${t('uiTitle')}</h3>
           <button>${t('uiCopy')}</button>
           <button>${t('uiOpenMap')}</button>
+          <button>${t('uiOpenEarth')}</button>
           <button>${t('uiClose')}</button>
         </div>
       `;
@@ -199,6 +206,7 @@ describe('Overlay Translation Logic', () => {
       expect(overlayHTML).toContain('Address (IS24)');
       expect(overlayHTML).toContain('Copy');
       expect(overlayHTML).toContain('Open map');
+      expect(overlayHTML).toContain('Open Google Earth');
       expect(overlayHTML).toContain('Close');
     });
   });
@@ -268,6 +276,7 @@ describe('Locale Bundle Loading', () => {
       uiTitle: 'Address (IS24)',
       uiCopy: 'Copy',
       uiOpenMap: 'Open map',
+      uiOpenEarth: 'Open Google Earth',
       uiClose: 'Close'
     };
     


### PR DESCRIPTION
Implements #2 
Changes:
- Adds button to open address in Google Earth
- Moves close button to top right
- Removes not found documents from readme

Since it was looking like this:￼￼
<img width="378" height="186" alt="image" src="https://github.com/user-attachments/assets/daa0db7b-c611-477c-81ca-047fec81f33c" />
I decided to move the close button to the top right:
<img width="342" height="148" alt="image" src="https://github.com/user-attachments/assets/b5788ba9-243a-4ff4-ac09-676b61796441" />
Let me know if you'd prefer to keep the Close text or maybe an icon instead of just an `X`
