### PR TITLE
feat: extract address decoding into standalone @immo24/decoder npm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     needs: typecheck
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -49,6 +49,10 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Run decoder package tests
+        run: bun run test
+        working-directory: packages/decoder
 
       - name: Run unit tests
         run: bunx vitest run

--- a/.github/workflows/publish-decoder.yml
+++ b/.github/workflows/publish-decoder.yml
@@ -1,0 +1,67 @@
+name: Publish @immo24/decoder
+
+on:
+  push:
+    tags:
+      - 'decoder/v*'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun x tsc --noEmit
+        working-directory: packages/decoder
+
+      - name: Run tests
+        run: bun run test
+        working-directory: packages/decoder
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Setup Node for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build package
+        run: bun x tsc --project tsconfig.json
+        working-directory: packages/decoder
+
+      - name: Publish to npm
+        run: npm publish --access public
+        working-directory: packages/decoder
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ bun run test:ui
 bun run test:coverage
 ```
 
-See [Testing Documentation](docs/TESTING.md) for detailed information.
-
 ## 📦 Release Process
 
 1. Bump version in `manifest.json` and `package.json`.
@@ -122,7 +120,6 @@ For detailed documentation, see the [docs/](docs/) directory:
 
 - **[Architecture](docs/ARCHITECTURE.md)** - System architecture and design patterns
 - **[TypeScript Migration](docs/MIGRATION.md)** - Migration guide and setup
-- **[Clean Code Review](docs/CLEAN_CODE_REVIEW.md)** - Code quality improvements
 - **[Privacy Policy](docs/PRIVACY_POLICY.md)** - Extension privacy policy
 
 ## ❤️ Contributing

--- a/bun.lock
+++ b/bun.lock
@@ -1,8 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "immo24-address-decoder",
+      "dependencies": {
+        "@immo24/decoder": "workspace:*",
+      },
       "devDependencies": {
         "@playwright/test": "^1.56.0",
         "@types/chrome": "^0.1.12",
@@ -16,6 +20,15 @@
         "rimraf": "^6.0.1",
         "sharp": "^0.34.4",
         "typescript": "^5.9.2",
+        "vitest": "^3.2.4",
+      },
+    },
+    "packages/decoder": {
+      "name": "@immo24/decoder",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "typescript": "^6.0.2",
         "vitest": "^3.2.4",
       },
     },
@@ -132,6 +145,8 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.4", "", { "os": "win32", "cpu": "x64" }, "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig=="],
+
+    "@immo24/decoder": ["@immo24/decoder@workspace:packages/decoder"],
 
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
@@ -427,6 +442,10 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "@immo24/decoder/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@immo24/decoder/typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+
     "glob/minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
 
     "happy-dom/@types/node": ["@types/node@20.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg=="],
@@ -450,6 +469,8 @@
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@immo24/decoder/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "happy-dom/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,213 +1,92 @@
-# Architecture Refactoring Summary
+# Architecture Overview
 
-## Before → After Comparison
+## Project Structure
 
-### Structure Evolution
-
-**Before (Monolithic):**
 ```
-src/
-├── bg.ts          (20 lines)
-├── content.ts     (400+ lines) ← Everything in one file!
-├── options.ts     (95 lines)
-├── types.ts       (25 lines)
-└── globals.d.ts   (10 lines)
-Total: ~550 lines in 5 files
-```
-
-**After (Modular):**
-```
-src/
-├── adapters/
-│   └── browser-api.ts          (100 lines) - Adapter Pattern
-├── strategies/
-│   └── decoding-strategies.ts  (150 lines) - Strategy + Chain of Responsibility
-├── services/
-│   └── settings-manager.ts     (90 lines)  - Singleton Pattern
-├── factories/
-│   └── overlay-factory.ts      (120 lines) - Factory Pattern
-├── builders/
-│   └── overlay-builder.ts      (180 lines) - Builder Pattern
-├── commands/
-│   └── user-commands.ts        (90 lines)  - Command Pattern
-├── bg.ts                       (20 lines)
-├── content.ts                  (150 lines) ← Drastically simplified!
-├── options.ts                  (95 lines)
-├── types.ts                    (25 lines)
-└── globals.d.ts                (10 lines)
-
-Total: 1,258 lines in 11 files
-7 directories (organized by pattern/responsibility)
+immo24-address-finder/
+├── packages/
+│   └── decoder/                        - Standalone npm package (@immo24/decoder)
+│       ├── src/
+│       │   ├── decoder.ts              - Decoding strategies + decodeAddress()
+│       │   ├── types.ts                - Address interface (English field names)
+│       │   └── index.ts               - Public API
+│       └── tests/
+│           └── decoder.test.ts
+├── src/                                - Browser extension
+│   ├── adapters/
+│   │   └── browser-api.ts             - Cross-browser API abstraction
+│   ├── builders/
+│   │   └── overlay-builder.ts         - Overlay builder (currently unused in build)
+│   ├── commands/
+│   │   └── user-commands.ts           - Command pattern (currently unused in build)
+│   ├── factories/
+│   │   └── overlay-factory.ts         - Style factory (currently unused in build)
+│   ├── services/
+│   │   └── settings-manager.ts        - Settings service (currently unused in build)
+│   ├── bg.ts                          - Background service worker
+│   ├── content.ts                     - Main content script
+│   ├── options.ts                     - Options page
+│   ├── types.ts                       - Shared extension types
+│   └── globals.d.ts                   - Browser API declarations
+├── scripts/
+│   ├── build.ts                       - esbuild build script
+│   └── make-icons.ts                  - Icon generator
+└── _locales/                          - i18n (de, en, es, it)
 ```
 
-## Design Patterns Implemented
+## Packages
 
-| # | Pattern | Location | Lines | Purpose |
-|---|---------|----------|-------|---------|
-| 1 | **Adapter** | `adapters/browser-api.ts` | 100 | Cross-browser API abstraction |
-| 2 | **Strategy** | `strategies/decoding-strategies.ts` | 150 | Multiple decoding algorithms |
-| 3 | **Chain of Responsibility** | `strategies/decoding-strategies.ts` | (included) | Try decoders in sequence |
-| 4 | **Singleton** | `services/settings-manager.ts` | 90 | Single settings instance |
-| 5 | **Factory** | `factories/overlay-factory.ts` | 120 | Create themes & styles |
-| 6 | **Builder** | `builders/overlay-builder.ts` | 180 | Construct complex overlays |
-| 7 | **Command** | `commands/user-commands.ts` | 90 | Encapsulate user actions |
+### @immo24/decoder
 
-## Benefits Achieved
+A standalone, platform-agnostic npm package containing all address decoding logic. It has no browser or DOM dependencies and works in Node.js and browser environments.
 
-### 1. **Maintainability** 📈
-- ✅ Clear separation of concerns
-- ✅ Each class has single responsibility
-- ✅ Easy to locate and fix bugs
-- ✅ Self-documenting code structure
-
-### 2. **Testability** 🧪
-- ✅ Can mock browser API adapter
-- ✅ Each pattern can be tested independently
-- ✅ No tight coupling to global objects
-- ✅ Pure functions in strategies
-
-### 3. **Extensibility** 🔧
-- ✅ Add new decoding strategies without touching existing code
-- ✅ Add new themes by extending factory
-- ✅ Add new commands easily
-- ✅ Swap implementations via interfaces
-
-### 4. **Reusability** ♻️
-- ✅ Strategies can be reused in other contexts
-- ✅ Builder can create different overlay types
-- ✅ Commands can be composed/chained
-- ✅ Factories provide consistent object creation
-
-### 5. **Code Quality** ⭐
-- ✅ SOLID principles applied
-- ✅ DRY (Don't Repeat Yourself)
-- ✅ Clear interfaces and contracts
-- ✅ Type-safe with TypeScript
-
-## Complexity Metrics
-
-| Metric | Before | After | Change |
-|--------|--------|-------|--------|
-| **Files** | 5 | 11 | +120% |
-| **Lines of Code** | 550 | 1,258 | +129% |
-| **Max File Size** | 400 lines | 180 lines | -55% |
-| **Cyclomatic Complexity** | High | Low | ✅ |
-| **Coupling** | High | Low | ✅ |
-| **Cohesion** | Low | High | ✅ |
-
-**Note:** While total LOC increased, each individual file is smaller and more focused. The increase is due to:
-- Proper separation of concerns
-- Interface definitions
-- Documentation comments
-- Type safety improvements
-
-## SOLID Principles Compliance
-
-### 1. Single Responsibility Principle (SRP) ✅
-- Each class has one reason to change
-- `SettingsManager` only manages settings
-- `DecodingStrategy` only decodes
-- `OverlayBuilder` only builds overlays
-
-### 2. Open/Closed Principle (OCP) ✅
-- Open for extension (add new strategies)
-- Closed for modification (existing strategies don't change)
-
-### 3. Liskov Substitution Principle (LSP) ✅
-- Any `DecodingStrategy` can replace another
-- Browser adapters are interchangeable
-
-### 4. Interface Segregation Principle (ISP) ✅
-- Small, focused interfaces
-- `Command` interface has single method
-- `DecodingStrategy` has single method
-
-### 5. Dependency Inversion Principle (DIP) ✅
-- Depend on abstractions, not concretions
-- `OverlayBuilder` depends on `Settings` interface
-- Code depends on `BrowserAPI` interface, not concrete implementation
-
-## Future Roadmap
-
-With this architecture, it's now easy to:
-
-### Short Term
-- [ ] Implement unit tests for each pattern
-- [ ] Add more decoding strategies
-- [ ] Create light/dark theme variants
-- [ ] Add keyboard command shortcuts
-
-### Medium Term
-- [ ] Implement Repository pattern for data access
-- [ ] Add Observer pattern for settings changes
-- [ ] Create Decorator pattern for overlay enhancements
-- [ ] Implement State pattern for overlay lifecycle
-
-### Long Term
-- [ ] Plugin system using Strategy pattern
-- [ ] User-configurable themes (Factory pattern)
-- [ ] Macro recording (Command pattern)
-- [ ] A/B testing framework
-
-## Migration Path
-
-### Phase 1: ✅ Patterns Introduced
-- Created all pattern implementations
-- Existing code still works
-- New patterns available for use
-
-### Phase 2: 🔄 Gradual Adoption (Next)
-- Refactor `content.ts` to use patterns
-- Replace inline code with pattern instances
-- Remove deprecated code
-
-### Phase 3: 📋 Complete Integration (Future)
-- All code uses patterns
-- Remove legacy implementations
-- Full test coverage
-
-## Example Usage
-
-### Before (Monolithic):
+**Exported API:**
 ```typescript
-// 400 lines of mixed concerns in content.ts
-const API = typeof browser !== 'undefined' ? browser : chrome;
-// Decoding logic inline...
-// Overlay creation inline...
-// Settings management inline...
+import { decodeAddress } from '@immo24/decoder';
+
+const address = decodeAddress(encodedString);
+// { street, houseNumber, postalCode, city, district }
 ```
 
-### After (Pattern-Based):
-```typescript
-// Clean, modular approach
-import { createBrowserAPI } from './adapters/browser-api.js';
-import { createDefaultDecodingChain } from './strategies/decoding-strategies.js';
-import { SettingsManager } from './services/settings-manager.js';
-import { OverlayBuilder } from './builders/overlay-builder.js';
+**Decoding strategies (Chain of Responsibility):**
+1. `Base64JsonStrategy` — decodes Base64/URL-safe Base64 with multi-encoding support (UTF-8, Windows-1252, ISO-8859-1)
+2. `DirectJsonStrategy` — parses direct or URL-encoded JSON
 
-const api = createBrowserAPI();
-const decoder = createDefaultDecodingChain();
-const settings = await SettingsManager.create(api);
+The chain tries strategies in order and returns the first successful result. Raw ImmoScout24 field names (`strasse`, `hausnummer`, `plz`, `ort`, `ortsteil`) are mapped to English names internally.
 
-const data = decoder.decode(encoded);
-const overlay = new OverlayBuilder(settings.getAll(), address, t)
-  .withCopyHandler(copyToClipboard)
-  .build();
+The extension imports this package via bun workspaces (`workspace:*`).
+
+## Extension Build
+
+The extension is built with esbuild (`bundle: true`, `format: iife`). The three entry points are:
+
+| File | Output | Purpose |
+|------|--------|---------|
+| `src/content.ts` | `content.js` | Injected into ImmoScout24 pages |
+| `src/bg.ts` | `bg.js` | Background service worker |
+| `src/options.ts` | `options.js` | Options page |
+
+Each entry point is bundled independently. `@immo24/decoder` is resolved via the workspace and bundled into `content.js`.
+
+## Data Flow
+
+```
+ImmoScout24 page
+  └─ obj_telekomInternetUrlAddition (Base64 JSON in page source)
+       └─ extractEncodedFromScripts()   [content.ts — DOM]
+            └─ decodeAddress()          [@immo24/decoder — pure]
+                 └─ Address { street, houseNumber, postalCode, city, district }
+                      └─ createOverlay()   [content.ts — DOM]
+                           └─ Overlay UI rendered on page
 ```
 
-## Conclusion
+## i18n
 
-✅ **7 Design Patterns** successfully implemented  
-✅ **Architecture** completely refactored  
-✅ **Code Quality** significantly improved  
-✅ **Maintainability** enhanced through modularity  
-✅ **Testability** now possible with clean interfaces  
-✅ **Extensibility** easy through pattern-based design  
+Translations live in `_locales/{de,en,es,it}/messages.json`. The extension uses `chrome.i18n.getMessage()` by default, with an optional locale override stored in sync storage.
 
-The project has evolved from a monolithic script to a well-architected, professional-grade extension following industry best practices.
+## CI/CD
 
----
-
-**Refactoring Date:** October 6, 2025  
-**Architecture Status:** ✅ Production Ready  
-**Pattern Coverage:** 100%
+| Workflow | Trigger | Jobs |
+|----------|---------|------|
+| `ci.yml` | push/PR to master | typecheck → unit tests (incl. decoder) → e2e tests → build → release |
+| `publish-decoder.yml` | tag `decoder/v*` | test → publish to npm |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 This directory contains all technical documentation for the immo24-address-decoder project.
 
+## 📦 npm Package
+
+- **[@immo24/decoder](../packages/decoder/README.md)** - Standalone address decoding package, usable in Node.js and browser
+
 ## 📐 Architecture & Design
 
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - System architecture overview, design patterns, and component interaction

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.0",
   "private": false,
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "clean": "rimraf dist web-ext-artifacts",
     "build": "bun run scripts/build.ts",
@@ -17,6 +20,9 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug"
+  },
+  "dependencies": {
+    "@immo24/decoder": "workspace:*"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.0",

--- a/packages/decoder/README.md
+++ b/packages/decoder/README.md
@@ -1,0 +1,94 @@
+# @immo24/decoder
+
+[![npm version](https://img.shields.io/npm/v/@immo24/decoder)](https://www.npmjs.com/package/@immo24/decoder)
+[![Tests](https://github.com/kidzki/immo24-address-finder/actions/workflows/publish-decoder.yml/badge.svg)](https://github.com/kidzki/immo24-address-finder/actions/workflows/publish-decoder.yml)
+[![License](https://img.shields.io/npm/l/@immo24/decoder)](./LICENSE)
+
+Decodes encoded address data from ImmoScout24 listing pages.
+
+ImmoScout24 embeds address information in the page as a Base64-encoded JSON string inside the `obj_telekomInternetUrlAddition` property. This package extracts and decodes that data into a structured `Address` object.
+
+## Installation
+
+```bash
+npm install @immo24/decoder
+```
+
+## Usage
+
+```typescript
+import { decodeAddress } from '@immo24/decoder';
+
+// Encoded string extracted from the ImmoScout24 page source
+const encoded = '...';
+
+const address = decodeAddress(encoded);
+if (address) {
+  console.log(address.street);      // e.g. "Musterstraße"
+  console.log(address.houseNumber); // e.g. "42"
+  console.log(address.postalCode);  // e.g. "10115"
+  console.log(address.city);        // e.g. "Berlin"
+  console.log(address.district);    // e.g. "Mitte"
+}
+```
+
+## Finding the encoded string
+
+The encoded address is embedded in the page HTML as a JSON property:
+
+```js
+"obj_telekomInternetUrlAddition": "<encoded-value>"
+```
+
+You can extract it from the page source via a regex:
+
+```typescript
+const match = html.match(/"obj_telekomInternetUrlAddition"\s*:\s*"([^"]+)"/);
+const encoded = match?.[1] ?? null;
+const address = decodeAddress(encoded);
+```
+
+## API
+
+### `decodeAddress(encoded: string | null): Address | null`
+
+Decodes an encoded address string. Returns `null` if the input is `null`, empty, or cannot be decoded.
+
+### `Address`
+
+```typescript
+interface Address {
+  street: string;
+  houseNumber: string;
+  postalCode: string;
+  city: string;
+  district: string;
+}
+```
+
+### Advanced usage
+
+For custom decoding strategies, the underlying building blocks are also exported:
+
+```typescript
+import {
+  DecodingStrategyChain,
+  Base64JsonStrategy,
+  DirectJsonStrategy,
+  type DecodingStrategy
+} from '@immo24/decoder';
+
+const chain = new DecodingStrategyChain()
+  .addStrategy(new Base64JsonStrategy())
+  .addStrategy(new DirectJsonStrategy());
+
+const raw = chain.decode(encoded);
+```
+
+## Requirements
+
+Node.js >= 16
+
+## License
+
+MIT

--- a/packages/decoder/bun.lock
+++ b/packages/decoder/bun.lock
@@ -1,0 +1,221 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@immo24/decoder",
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "typescript": "^6.0.2",
+        "vitest": "^3.2.4",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.0", "", { "os": "android", "cpu": "arm" }, "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.0", "", { "os": "android", "cpu": "arm64" }, "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.0", "", { "os": "none", "cpu": "arm64" }, "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "rollup": ["rollup@4.60.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.0", "@rollup/rollup-android-arm64": "4.60.0", "@rollup/rollup-darwin-arm64": "4.60.0", "@rollup/rollup-darwin-x64": "4.60.0", "@rollup/rollup-freebsd-arm64": "4.60.0", "@rollup/rollup-freebsd-x64": "4.60.0", "@rollup/rollup-linux-arm-gnueabihf": "4.60.0", "@rollup/rollup-linux-arm-musleabihf": "4.60.0", "@rollup/rollup-linux-arm64-gnu": "4.60.0", "@rollup/rollup-linux-arm64-musl": "4.60.0", "@rollup/rollup-linux-loong64-gnu": "4.60.0", "@rollup/rollup-linux-loong64-musl": "4.60.0", "@rollup/rollup-linux-ppc64-gnu": "4.60.0", "@rollup/rollup-linux-ppc64-musl": "4.60.0", "@rollup/rollup-linux-riscv64-gnu": "4.60.0", "@rollup/rollup-linux-riscv64-musl": "4.60.0", "@rollup/rollup-linux-s390x-gnu": "4.60.0", "@rollup/rollup-linux-x64-gnu": "4.60.0", "@rollup/rollup-linux-x64-musl": "4.60.0", "@rollup/rollup-openbsd-x64": "4.60.0", "@rollup/rollup-openharmony-arm64": "4.60.0", "@rollup/rollup-win32-arm64-msvc": "4.60.0", "@rollup/rollup-win32-ia32-msvc": "4.60.0", "@rollup/rollup-win32-x64-gnu": "4.60.0", "@rollup/rollup-win32-x64-msvc": "4.60.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+  }
+}

--- a/packages/decoder/package.json
+++ b/packages/decoder/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@immo24/decoder",
+  "version": "0.1.0",
+  "description": "Decode encoded address data from ImmoScout24 listings",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "immobilienscout24",
+    "immo24",
+    "address",
+    "decoder",
+    "real-estate"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "typescript": "^6.0.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/decoder/src/decoder.ts
+++ b/packages/decoder/src/decoder.ts
@@ -1,19 +1,17 @@
-// Strategy Pattern for Address Decoding
-// Different strategies for decoding encoded address data
+import type { Address } from './types.js';
 
 export interface DecodingStrategy {
-  decode(encoded: string): any | null;
+  decode(encoded: string): unknown | null;
 }
 
-// Base64 + JSON Strategy
 export class Base64JsonStrategy implements DecodingStrategy {
-  decode(encoded: string): any | null {
+  decode(encoded: string): unknown | null {
     try {
       const normalized = this.normalizeBase64(encoded);
       const bytes = this.base64ToBytes(normalized);
       const jsonString = this.bytesToString(bytes);
       const fixed = this.fixDoubleUtf8(jsonString);
-      
+
       try {
         return JSON.parse(fixed);
       } catch {
@@ -32,31 +30,27 @@ export class Base64JsonStrategy implements DecodingStrategy {
     const norm = this.normalizeBase64(b64);
     const pad = norm.length % 4 === 0 ? '' : '='.repeat(4 - (norm.length % 4));
     const bin = atob(norm + pad);
-    return Uint8Array.from(bin, c => c.charCodeAt(0));
+    return Uint8Array.from(bin, (c: string) => c.charCodeAt(0));
   }
 
   private bytesToString(bytes: Uint8Array): string {
-    // Try UTF-8 first
     try {
       return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
     } catch {}
-    
-    // Try Windows-1252
+
     try {
       return new TextDecoder('windows-1252', { fatal: true }).decode(bytes);
     } catch {}
-    
-    // Try ISO-8859-1
+
     try {
       return new TextDecoder('iso-8859-1', { fatal: true }).decode(bytes);
     } catch {}
-    
-    // Fallback: manual conversion
+
     let s = '';
     for (let i = 0; i < bytes.length; i++) {
       s += String.fromCharCode(bytes[i] & 0xff);
     }
-    
+
     try {
       return decodeURIComponent(escape(s));
     } catch {
@@ -67,7 +61,7 @@ export class Base64JsonStrategy implements DecodingStrategy {
   private fixDoubleUtf8(s: string): string {
     if (!s) return s;
     if (!/[Ã][\x80-\xBF]/.test(s)) return s;
-    
+
     const bytes = Uint8Array.from([...s].map(ch => ch.charCodeAt(0) & 0xff));
     try {
       return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
@@ -77,9 +71,8 @@ export class Base64JsonStrategy implements DecodingStrategy {
   }
 }
 
-// Direct JSON Strategy
 export class DirectJsonStrategy implements DecodingStrategy {
-  decode(encoded: string): any | null {
+  decode(encoded: string): unknown | null {
     try {
       return JSON.parse(encoded);
     } catch {
@@ -92,7 +85,6 @@ export class DirectJsonStrategy implements DecodingStrategy {
   }
 }
 
-// Chain of Responsibility Pattern for multiple strategies
 export class DecodingStrategyChain {
   private strategies: DecodingStrategy[] = [];
 
@@ -101,10 +93,9 @@ export class DecodingStrategyChain {
     return this;
   }
 
-  decode(encoded: string | null): any | null {
+  decode(encoded: string | null): unknown | null {
     if (!encoded) return null;
 
-    // URL decode first
     let urlDecoded: string;
     try {
       urlDecoded = decodeURIComponent(String(encoded).replace(/\+/g, '%20'));
@@ -112,7 +103,6 @@ export class DecodingStrategyChain {
       urlDecoded = encoded;
     }
 
-    // Try each strategy in order
     for (const strategy of this.strategies) {
       const result = strategy.decode(urlDecoded);
       if (result !== null) {
@@ -124,9 +114,37 @@ export class DecodingStrategyChain {
   }
 }
 
-// Factory function to create the default decoding chain
 export function createDefaultDecodingChain(): DecodingStrategyChain {
   return new DecodingStrategyChain()
     .addStrategy(new Base64JsonStrategy())
     .addStrategy(new DirectJsonStrategy());
+}
+
+function sanitize(text: string): string {
+  if (!text) return text;
+  const bytes = Uint8Array.from([...text].map(ch => ch.charCodeAt(0) & 0xff));
+  let fixed = text;
+  if (/[Ã][\x80-\xBF]/.test(text)) {
+    try {
+      fixed = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    } catch {}
+  }
+  return fixed.replace(/\uFFFD/g, '');
+}
+
+function toAddress(obj: Record<string, unknown>): Address {
+  return {
+    street: sanitize(String(obj.strasse || obj.street || '')),
+    houseNumber: sanitize(String(obj.hausnummer || obj.houseNumber || obj.housenumber || '')),
+    postalCode: sanitize(String(obj.plz || obj.zip || obj.postalCode || '')),
+    city: sanitize(String(obj.ort || obj.city || '')),
+    district: sanitize(String(obj.ortsteil || obj.district || ''))
+  };
+}
+
+export function decodeAddress(encoded: string | null): Address | null {
+  const chain = createDefaultDecodingChain();
+  const obj = chain.decode(encoded);
+  if (!obj || typeof obj !== 'object') return null;
+  return toAddress(obj as Record<string, unknown>);
 }

--- a/packages/decoder/src/index.ts
+++ b/packages/decoder/src/index.ts
@@ -1,0 +1,3 @@
+export { decodeAddress, createDefaultDecodingChain, DecodingStrategyChain, Base64JsonStrategy, DirectJsonStrategy } from './decoder.js';
+export type { DecodingStrategy } from './decoder.js';
+export type { Address } from './types.js';

--- a/packages/decoder/src/types.ts
+++ b/packages/decoder/src/types.ts
@@ -1,0 +1,7 @@
+export interface Address {
+  street: string;
+  houseNumber: string;
+  postalCode: string;
+  city: string;
+  district: string;
+}

--- a/packages/decoder/tests/decoder.test.ts
+++ b/packages/decoder/tests/decoder.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { decodeAddress, Base64JsonStrategy, DirectJsonStrategy, DecodingStrategyChain } from '../src/index.js';
+
+function toBase64(obj: object): string {
+  return Buffer.from(JSON.stringify(obj)).toString('base64');
+}
+
+describe('decodeAddress', () => {
+  it('decodes a base64-encoded address with German field names', () => {
+    const encoded = toBase64({
+      strasse: 'Musterstraße',
+      hausnummer: '42',
+      plz: '10115',
+      ort: 'Berlin',
+      ortsteil: 'Mitte'
+    });
+
+    const result = decodeAddress(encoded);
+
+    expect(result).toEqual({
+      street: 'Musterstraße',
+      houseNumber: '42',
+      postalCode: '10115',
+      city: 'Berlin',
+      district: 'Mitte'
+    });
+  });
+
+  it('decodes a base64-encoded address with English field names', () => {
+    const encoded = toBase64({
+      street: 'Example Street',
+      houseNumber: '1',
+      postalCode: '80331',
+      city: 'Munich',
+      district: ''
+    });
+
+    const result = decodeAddress(encoded);
+
+    expect(result).toEqual({
+      street: 'Example Street',
+      houseNumber: '1',
+      postalCode: '80331',
+      city: 'Munich',
+      district: ''
+    });
+  });
+
+  it('decodes a URL-safe base64 encoded address', () => {
+    const normal = Buffer.from(JSON.stringify({ strasse: 'Straße', hausnummer: '1', plz: '10115', ort: 'Berlin', ortsteil: '' })).toString('base64');
+    const urlSafe = normal.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+
+    const result = decodeAddress(urlSafe);
+
+    expect(result?.street).toBe('Straße');
+    expect(result?.city).toBe('Berlin');
+  });
+
+  it('decodes a directly JSON-encoded address', () => {
+    const encoded = JSON.stringify({ strasse: 'Hauptstraße', hausnummer: '5', plz: '50667', ort: 'Köln', ortsteil: '' });
+
+    const result = decodeAddress(encoded);
+
+    expect(result?.street).toBe('Hauptstraße');
+    expect(result?.postalCode).toBe('50667');
+  });
+
+  it('returns null for null input', () => {
+    expect(decodeAddress(null)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(decodeAddress('')).toBeNull();
+  });
+
+  it('returns null for non-decodable input', () => {
+    expect(decodeAddress('not-valid-base64-or-json!!!###')).toBeNull();
+  });
+
+  it('handles missing fields gracefully', () => {
+    const encoded = toBase64({ strasse: 'Musterstraße' });
+    const result = decodeAddress(encoded);
+
+    expect(result?.street).toBe('Musterstraße');
+    expect(result?.houseNumber).toBe('');
+    expect(result?.postalCode).toBe('');
+    expect(result?.city).toBe('');
+    expect(result?.district).toBe('');
+  });
+});
+
+describe('Base64JsonStrategy', () => {
+  it('decodes valid base64 JSON', () => {
+    const strategy = new Base64JsonStrategy();
+    const encoded = Buffer.from('{"key":"value"}').toString('base64');
+    expect(strategy.decode(encoded)).toEqual({ key: 'value' });
+  });
+
+  it('returns null for invalid input', () => {
+    const strategy = new Base64JsonStrategy();
+    expect(strategy.decode('!!!invalid!!!')).toBeNull();
+  });
+});
+
+describe('DirectJsonStrategy', () => {
+  it('decodes valid JSON string', () => {
+    const strategy = new DirectJsonStrategy();
+    expect(strategy.decode('{"key":"value"}')).toEqual({ key: 'value' });
+  });
+
+  it('decodes URL-encoded JSON', () => {
+    const strategy = new DirectJsonStrategy();
+    const encoded = encodeURIComponent('{"key":"value"}');
+    expect(strategy.decode(encoded)).toEqual({ key: 'value' });
+  });
+
+  it('returns null for invalid input', () => {
+    const strategy = new DirectJsonStrategy();
+    expect(strategy.decode('not json')).toBeNull();
+  });
+});
+
+describe('DecodingStrategyChain', () => {
+  it('tries strategies in order and returns first match', () => {
+    const chain = new DecodingStrategyChain()
+      .addStrategy(new Base64JsonStrategy())
+      .addStrategy(new DirectJsonStrategy());
+
+    const b64 = Buffer.from('{"source":"base64"}').toString('base64');
+    expect(chain.decode(b64)).toEqual({ source: 'base64' });
+  });
+
+  it('falls through to next strategy when first fails', () => {
+    const chain = new DecodingStrategyChain()
+      .addStrategy(new Base64JsonStrategy())
+      .addStrategy(new DirectJsonStrategy());
+
+    expect(chain.decode('{"source":"direct"}')).toEqual({ source: 'direct' });
+  });
+
+  it('returns null when no strategy matches', () => {
+    const chain = new DecodingStrategyChain()
+      .addStrategy(new Base64JsonStrategy())
+      .addStrategy(new DirectJsonStrategy());
+
+    expect(chain.decode('garbage input xyz')).toBeNull();
+  });
+
+  it('returns null for null input', () => {
+    const chain = new DecodingStrategyChain();
+    expect(chain.decode(null)).toBeNull();
+  });
+});

--- a/packages/decoder/tsconfig.json
+++ b/packages/decoder/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2020"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/decoder/vitest.config.ts
+++ b/packages/decoder/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node'
+  }
+});

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -49,7 +49,7 @@ async function buildJs(targetDir: string): Promise<void> {
   await esbuild({
     entryPoints: jsEntries.map(f => path.join(root, 'src', f)),
     outdir: targetDir,
-    bundle: false,
+    bundle: true,
     minify: true,
     sourcemap: false,
     target: ['chrome109', 'firefox109'],

--- a/src/builders/overlay-builder.ts
+++ b/src/builders/overlay-builder.ts
@@ -1,6 +1,7 @@
 // Builder Pattern for Overlay Construction
 
-import type { Address, Settings } from '../types.js';
+import type { Settings } from '../types.js';
+import type { Address } from '@immo24/decoder';
 import { OverlayStyleFactory, AddressFormatter } from '../factories/overlay-factory.js';
 
 export class OverlayBuilder {
@@ -64,11 +65,11 @@ export class OverlayBuilder {
     line.style.whiteSpace = 'pre-wrap';
 
     const sanitizedAddress: Address = {
-      strasse: AddressFormatter.sanitize(this.address.strasse),
-      hausnummer: AddressFormatter.sanitize(this.address.hausnummer),
-      plz: AddressFormatter.sanitize(this.address.plz),
-      ort: AddressFormatter.sanitize(this.address.ort),
-      ortsteil: AddressFormatter.sanitize(this.address.ortsteil)
+      street: AddressFormatter.sanitize(this.address.street),
+      houseNumber: AddressFormatter.sanitize(this.address.houseNumber),
+      postalCode: AddressFormatter.sanitize(this.address.postalCode),
+      city: AddressFormatter.sanitize(this.address.city),
+      district: AddressFormatter.sanitize(this.address.district)
     };
 
     const formatted = AddressFormatter.format(sanitizedAddress);
@@ -103,11 +104,11 @@ export class OverlayBuilder {
 
     if (this.onCopy) {
       const sanitizedAddress: Address = {
-        strasse: AddressFormatter.sanitize(this.address.strasse),
-        hausnummer: AddressFormatter.sanitize(this.address.hausnummer),
-        plz: AddressFormatter.sanitize(this.address.plz),
-        ort: AddressFormatter.sanitize(this.address.ort),
-        ortsteil: AddressFormatter.sanitize(this.address.ortsteil)
+        street: AddressFormatter.sanitize(this.address.street),
+        houseNumber: AddressFormatter.sanitize(this.address.houseNumber),
+        postalCode: AddressFormatter.sanitize(this.address.postalCode),
+        city: AddressFormatter.sanitize(this.address.city),
+        district: AddressFormatter.sanitize(this.address.district)
       };
       
       const addrLine = AddressFormatter.format(sanitizedAddress);
@@ -153,10 +154,10 @@ export class OverlayBuilder {
 
   private buildMapHref(): string {
     const parts = [
-      this.address.strasse,
-      this.address.hausnummer,
-      this.address.plz,
-      this.address.ort
+      this.address.street,
+      this.address.houseNumber,
+      this.address.postalCode,
+      this.address.city
     ].filter(Boolean);
 
     const q = encodeURIComponent(parts.join(' '));

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,3 +1,4 @@
+import { decodeAddress } from '@immo24/decoder';
 import type { Address, Settings, ToggleOverlayMessage } from './types.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -54,71 +55,6 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
     if (bundle) {
       t = (k: string) => (k in bundle ? bundle[k] : k);
     }
-  }
-
-  function b64Normalize(b64: string) {
-    return (b64 || '').replace(/-/g, '+').replace(/_/g, '/').replace(/\s+/g, '');
-  }
-
-  function b64ToBytes(b64: string): Uint8Array {
-    const norm = b64Normalize(b64);
-    const pad = norm.length % 4 === 0 ? '' : '='.repeat(4 - (norm.length % 4));
-    const bin = atob(norm + pad);
-    return Uint8Array.from(bin, c => c.charCodeAt(0));
-  }
-
-  function bytesToStringSmart(bytes: Uint8Array): string {
-    try { return new TextDecoder('utf-8', { fatal: true }).decode(bytes); } catch {}
-    try { return new TextDecoder('windows-1252', { fatal: true }).decode(bytes); } catch {}
-    try { return new TextDecoder('iso-8859-1', { fatal: true }).decode(bytes); } catch {}
-    let s = '';
-    for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i] & 0xff);
-    try { return decodeURIComponent(escape(s)); } catch { return s; }
-  }
-
-  function fixDoubleUtf8(s: string) {
-    if (!s) return s;
-    if (!/[Ã][\x80-\xBF]/.test(s)) return s;
-    const bytes = Uint8Array.from([...s].map(ch => ch.charCodeAt(0) & 0xff));
-    try { return new TextDecoder('utf-8', { fatal: true }).decode(bytes); } catch { return s; }
-  }
-
-  function sanitizeText(s: string) {
-    if (!s) return s;
-    const fixed = fixDoubleUtf8(s);
-    return fixed.replace(/\uFFFD/g, '');
-  }
-
-  function decodeTelekomAddition(encoded: string | null): any | null {
-    if (!encoded) return null;
-    
-    let urlDecoded: string;
-    try {
-      urlDecoded = decodeURIComponent(String(encoded).replace(/\+/g, '%20'));
-    } catch {
-      urlDecoded = encoded;
-    }
-    
-    // Try Base64 decoding first
-    let jsonCandidate: string | null = null;
-    try {
-      const bytes = b64ToBytes(urlDecoded);
-      jsonCandidate = bytesToStringSmart(bytes);
-    } catch {
-      // Not Base64, will try direct JSON parsing below
-    }
-    
-    if (jsonCandidate) {
-      jsonCandidate = fixDoubleUtf8(jsonCandidate);
-      try { return JSON.parse(jsonCandidate); } catch {}
-      try { return JSON.parse(decodeURIComponent(jsonCandidate)); } catch {}
-    }
-    
-    // Try direct JSON parsing
-    try { return JSON.parse(urlDecoded); } catch {}
-    try { return JSON.parse(decodeURIComponent(urlDecoded)); } catch {}
-    
-    return null;
   }
 
   function extractEncodedFromScripts(): string | null {
@@ -228,16 +164,12 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
     line.style.margin = '6px 0 10px';
     line.style.whiteSpace = 'pre-wrap';
 
-    const strasse = sanitizeText(address.strasse);
-    const hausnummer = sanitizeText(address.hausnummer);
-    const plz = sanitizeText(address.plz);
-    const ort = sanitizeText(address.ort);
-    const ortsteil = sanitizeText(address.ortsteil);
+    const { street, houseNumber, postalCode, city, district } = address;
 
     const addrLine =
-      [strasse, hausnummer].filter(Boolean).join(' ') +
-      ((plz || ort) ? `\n${[plz, ort].filter(Boolean).join(' ')}` : '') +
-      (ortsteil ? `\n(${ortsteil})` : '');
+      [street, houseNumber].filter(Boolean).join(' ') +
+      ((postalCode || city) ? `\n${[postalCode, city].filter(Boolean).join(' ')}` : '') +
+      (district ? `\n(${district})` : '');
 
     line.textContent = addrLine || t('uiNoAddress');
 
@@ -259,7 +191,7 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
 
     const mapBtn = document.createElement('a');
     mapBtn.setAttribute('style', ghost + ' text-decoration:none; display:inline-flex; align-items:center; justify-content:center;');
-    mapBtn.href = buildMapHref(mapProvider, [strasse, hausnummer, plz, ort]);
+    mapBtn.href = buildMapHref(mapProvider, [street, houseNumber, postalCode, city]);
     mapBtn.target = '_blank';
     mapBtn.rel = 'noopener';
     mapBtn.textContent = t('uiOpenMap');
@@ -327,17 +259,11 @@ const FEEDBACK_MESSAGE_DURATION = 1500;
     const enc = extractEncodedFromScripts();
     if (!enc) return;
     
-    const obj = decodeTelekomAddition(enc) || {};
-    const address: Address = {
-      strasse: obj.strasse || obj.street || '',
-      hausnummer: obj.hausnummer || obj.houseNumber || obj.housenumber || '',
-      plz: obj.plz || obj.zip || obj.postalCode || '',
-      ort: obj.ort || obj.city || '',
-      ortsteil: obj.ortsteil || obj.district || ''
-    };
-    
+    const address = decodeAddress(enc);
+    if (!address) return;
+
     if (settings.autoCopy) {
-      const addressParts = [address.strasse, address.hausnummer, address.plz, address.ort]
+      const addressParts = [address.street, address.houseNumber, address.postalCode, address.city]
         .filter(Boolean)
         .join(' ');
       copyToClipboard(addressParts);

--- a/src/factories/overlay-factory.ts
+++ b/src/factories/overlay-factory.ts
@@ -74,16 +74,16 @@ export class AddressFormatter {
   static format(address: Address): string {
     const parts: string[] = [];
     
-    if (address.strasse || address.hausnummer) {
-      parts.push([address.strasse, address.hausnummer].filter(Boolean).join(' '));
+    if (address.street || address.houseNumber) {
+      parts.push([address.street, address.houseNumber].filter(Boolean).join(' '));
     }
-    
-    if (address.plz || address.ort) {
-      parts.push([address.plz, address.ort].filter(Boolean).join(' '));
+
+    if (address.postalCode || address.city) {
+      parts.push([address.postalCode, address.city].filter(Boolean).join(' '));
     }
-    
-    if (address.ortsteil) {
-      parts.push(`(${address.ortsteil})`);
+
+    if (address.district) {
+      parts.push(`(${address.district})`);
     }
     
     return parts.join('\n');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 // Shared types for the extension
 
+export type { Address } from '@immo24/decoder';
+
 export type MapProvider = 'google' | 'osm' | 'apple';
 export type Position = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
 export type Theme = 'dark' | 'light';
@@ -11,14 +13,6 @@ export interface Settings {
   position: Position;
   theme: Theme;
   localeOverride: LocaleOverride;
-}
-
-export interface Address {
-  strasse: string;
-  hausnummer: string;
-  plz: string;
-  ort: string;
-  ortsteil: string;
 }
 
 export interface ToggleOverlayMessage { type: 'IS24_TOGGLE_OVERLAY'; }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,10 @@
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@immo24/decoder": ["packages/decoder/src/index.ts"]
     }
   },
-  "include": ["src/**/*.ts", "scripts/**/*.ts"],
+  "include": ["src/**/*.ts", "scripts/**/*.ts", "packages/decoder/src/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary 

Implementation is for #1  

- Extracts the address decoding logic into a standalone npm package `@immo24/decoder`
- Removes duplicate decoding code from the extension — single source of truth
- Introduces English-named `Address` type (`street`, `houseNumber`, `postalCode`, `city`, `district`)
- Adds 17 unit tests and a README with usage docs and badges

## Changes

**New: `packages/decoder/`**
- Pure decoding logic with no browser/DOM dependencies — works in Node.js and browser
- `decodeAddress(encoded)` as the main entry point
- Handles Base64, URL-safe Base64, direct JSON, and various character encodings
- Maps raw ImmoScout24 German field names to English `Address` type internally

**Extension**
- Imports `Address` and `decodeAddress` from `@immo24/decoder` via bun workspaces
- `src/strategies/decoding-strategies.ts` deleted (replaced by package)
- Inline decoding functions removed from `content.ts`
- All field references updated to English names
- Build switched to `bundle: true` to support npm imports

**CI/CD**
- `publish-decoder.yml`: runs tests and publishes to npm on `decoder/v*` tags (requires `NPM_TOKEN` secret)
- `ci.yml`: decoder package tests added to the unit-tests job

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes (extension unit tests)
- [ ] `bun run test` in `packages/decoder` passes (17 decoder tests)
- [ ] `bun run build` produces valid extension artifacts
- [ ] Add `NPM_TOKEN` secret to repo settings before merging (for publish workflow)